### PR TITLE
Improved batch processing example in tutorial

### DIFF
--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -406,33 +406,6 @@ Using the ImageSequence Iterator class
         # ...do something to frame...
 
 
-Batch processing with pathlib
------------------------------
-
-This example uses Pillow together with pathlib, in order to reduce the quality of all PNG images in a folder:
-
-::
-
-    from pathlib import Path
-    from PIL import Image
-
-
-    def compress_image(source_path, dest_path):
-        with Image.open(source_path) as img:
-            if img.mode != "RGB":
-                img = img.convert("RGB")
-            img.save(dest_path, "JPEG", optimize=True, quality=80)
-
-
-    base_directory = Path.cwd()
-
-    for path in base_directory.iterdir():
-        if path.suffix == ".png":
-            print(path)
-            compress_image(path, filepath.stem + ".jpg")
-
-
-
 PostScript printing
 -------------------
 
@@ -519,6 +492,33 @@ Reading from a tar archive
 
     fp = TarIO.TarIO("Tests/images/hopper.tar", "hopper.jpg")
     im = Image.open(fp)
+
+
+Batch processing
+^^^^^^^^^^^^^^^^
+
+This example uses Pillow together with pathlib, in order to reduce the quality of all PNG images in a folder:
+
+::
+
+    from pathlib import Path
+    from PIL import Image
+
+
+    def compress_image(source_path, dest_path):
+        with Image.open(source_path) as img:
+            if img.mode != "RGB":
+                img = img.convert("RGB")
+            img.save(dest_path, "JPEG", optimize=True, quality=80)
+
+
+    base_directory = Path.cwd()
+
+    for path in base_directory.iterdir():
+        if path.suffix == ".png":
+            print(path)
+            compress_image(path, filepath.stem + ".jpg")
+
 
 Controlling the decoder
 -----------------------

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -513,7 +513,7 @@ in the current directory can be saved as JPEGs at reduced quality.
             img.save(dest_path, "JPEG", optimize=True, quality=80)
 
 
-    paths = [path for path in os.listdir(".") if path.endsWith(".png")]
+    paths = glob.glob(".png")
     for path in paths:
         compress_image(path, path[:-4] + ".jpg")
 
@@ -524,7 +524,7 @@ the example could be modified to use ``pathlib`` instead of ``os``.
 
     from pathlib import Path
 
-    paths = [path for path in Path.cwd().iterdir() if path.suffix == ".png"]
+    paths = Path(".").glob("*.png")
     for path in paths:
         compress_image(path, filepath.stem + ".jpg")
 

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -417,13 +417,11 @@ This example uses Pillow together with pathlib, in order to reduce the quality o
     from PIL import Image
 
 
-    def compress_image(filepath):
-        file = filepath.stem
-        with Image.open(filepath) as img:
+    def compress_image(source_path, dest_path):
+        with Image.open(source_path) as img:
             if img.mode != "RGB":
                 img = img.convert("RGB")
-            img.save(file + ".jpg", "JPEG", optimize=True, quality=80)
-        return
+            img.save(dest_path, "JPEG", optimize=True, quality=80)
 
 
     base_directory = Path.cwd()
@@ -431,7 +429,7 @@ This example uses Pillow together with pathlib, in order to reduce the quality o
     for path in base_directory.iterdir():
         if path.suffix == ".png":
             print(path)
-            compress_image(path)
+            compress_image(path, filepath.stem + ".jpg")
 
 
 

--- a/docs/handbook/tutorial.rst
+++ b/docs/handbook/tutorial.rst
@@ -497,11 +497,12 @@ Reading from a tar archive
 Batch processing
 ^^^^^^^^^^^^^^^^
 
-This example uses Pillow together with pathlib, in order to reduce the quality of all PNG images in a folder:
+Operations can be applied to multiple image files. For example, all PNG images
+in the current directory can be saved as JPEGs at reduced quality.
 
 ::
 
-    from pathlib import Path
+    import os
     from PIL import Image
 
 
@@ -512,12 +513,20 @@ This example uses Pillow together with pathlib, in order to reduce the quality o
             img.save(dest_path, "JPEG", optimize=True, quality=80)
 
 
-    base_directory = Path.cwd()
+    paths = [path for path in os.listdir(".") if path.endsWith(".png")]
+    for path in paths:
+        compress_image(path, path[:-4] + ".jpg")
 
-    for path in base_directory.iterdir():
-        if path.suffix == ".png":
-            print(path)
-            compress_image(path, filepath.stem + ".jpg")
+Since images can also be opened from a ``Path`` from the ``pathlib`` module,
+the example could be modified to use ``pathlib`` instead of ``os``.
+
+::
+
+    from pathlib import Path
+
+    paths = [path for path in Path.cwd().iterdir() if path.suffix == ".png"]
+    for path in paths:
+        compress_image(path, filepath.stem + ".jpg")
 
 
 Controlling the decoder


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/5862

- I moved all the pathlib logic outside of the function. This should help clarify to the user what is Pillow and what is pathlib.
- I moved the example under the "More on reading images" heading. It seems like a good place for it to me.
- I added an example using `os` instead of `pathlib`.

You can see how this looks at https://pillow-radarhere.readthedocs.io/en/pathlib/handbook/tutorial.html#batch-processing